### PR TITLE
Increase packing efficiency by sorting equal-height boxes by width

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ export default function potpack(boxes) {
         maxWidth = Math.max(maxWidth, box.w);
     }
 
-    // sort the boxes for insertion by height, descending
-    boxes.sort((a, b) => b.h - a.h);
+    // sort the boxes for insertion by height (or width if equal), descending
+    boxes.sort((a, b) => b.h - a.h || b.w - a.w);
 
     // aim for a squarish resulting container,
     // slightly adjusted for sub-100% space utilization


### PR DESCRIPTION
Implementing this simple change in my project saw consistent improvements of 1% packing efficiency.

Thank you for such a useful library!

## Before: 96.95% space efficiency
![potpack_old](https://github.com/user-attachments/assets/05341f28-5621-4cae-8c81-c7eaa4af68dc)

## After: 97.96% space efficiency
![potpack_new](https://github.com/user-attachments/assets/26723ce3-5259-4e2b-ba04-f34d06fad99f)
