### PR TITLE
Remove "declare module" in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,39 +1,37 @@
-declare module "potpack" {
-  export interface PotpackBox {
-    w: number;
-    h: number;
-    /**
-     * X coordinate in the resulting container.
-     */
-    x?: number;
-    /**
-     * Y coordinate in the resulting container.
-     */
-    y?: number;
-  }
-
-  interface PotpackStats {
-    /**
-     * Width of the resulting container.
-     */
-    w: number;
-    /**
-     * Height of the resulting container.
-     */
-    h: number;
-    /**
-     * The space utilization value (0 to 1). Higher is better.
-     */
-    fill: number;
-  }
-
+export interface PotpackBox {
+  w: number;
+  h: number;
   /**
-   * Packs 2D rectangles into a near-square container.
-   *
-   * Mutates the {@link boxes} array: it's sorted by height,
-   * and box objects are augmented with `x`, `y` coordinates.
+   * X coordinate in the resulting container.
    */
-  const potpack: (boxes: PotpackBox[]) => PotpackStats;
-
-  export default potpack;
+  x?: number;
+  /**
+   * Y coordinate in the resulting container.
+   */
+  y?: number;
 }
+
+interface PotpackStats {
+  /**
+   * Width of the resulting container.
+   */
+  w: number;
+  /**
+   * Height of the resulting container.
+   */
+  h: number;
+  /**
+   * The space utilization value (0 to 1). Higher is better.
+   */
+  fill: number;
+}
+
+/**
+ * Packs 2D rectangles into a near-square container.
+ *
+ * Mutates the {@link boxes} array: it's sorted by height,
+ * and box objects are augmented with `x`, `y` coordinates.
+ */
+declare const potpack: (boxes: PotpackBox[]) => PotpackStats;
+
+export default potpack;


### PR DESCRIPTION
This doesn't change any functionality. It increases compatibility with third-party tooling like esm.sh.

I ran into an issue using [the esm.sh VSCode extension](https://github.com/esm-dev/vscode) and an importmap. Put simply, the module name in the `declare module "potpack"` needs to be renamed for every importmap key, which is much harder to do. Omitting `declare module "potpack"` doesn't change anything functionally, and is more in standard with other NPM packages.

Thank you!